### PR TITLE
Print final newline

### DIFF
--- a/R/image.R
+++ b/R/image.R
@@ -29,8 +29,8 @@ im2ansi <- function(im, width = 80, font_aspect = 0.45, full_colour = FALSE) {
   # Collapse
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   rows <- apply(mat, 1, paste0, collapse = "")
-  rows <- paste0(rows, reset_code)
-  paste0(rows, collapse="\n")
+  rows <- paste0(rows, reset_code, "\n")
+  paste0(rows, collapse = "")
 }
 
 


### PR DESCRIPTION
Currently, when R is run in a terminal, the prompt appears after the image. This change fixes that by printing a final newline.